### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,34 +85,38 @@ go test
 `go mod edit -replace github.com/tursodatabase/turso=/path/to/turso/bindings/go`
 
 ```go
+package main
+
 import (
-    "fmt"
-    "database/sql"
-    _"github.com/tursodatabase/turso-go"
+	"database/sql"
+	"fmt"
+	"os"
+	_ "github.com/tursodatabase/turso-go"
 )
 
 func main() {
 	conn, err := sql.Open("turso", ":memory:")
 	if err != nil {
-        fmt.Printf("Error: %v\n", err)
-        os.Exit(1)
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
 	}
-    sql := "CREATE table go_turso (foo INTEGER, bar TEXT)"
-    _ = conn.Exec(sql)
+	sql := "CREATE table go_turso (foo INTEGER, bar TEXT)"
+	_, _ = conn.Exec(sql)
 
-    sql = "INSERT INTO go_turso (foo, bar) values (?, ?)"
-    stmt, _ := conn.Prepare(sql)
-    defer stmt.Close()
-    _  = stmt.Exec(42, "turso")
-    rows, _ := conn.Query("SELECT * from go_turso")
-    defer rows.Close()
-    for rows.Next() {
-        var a int
-        var b string
+	sql = "INSERT INTO go_turso (foo, bar) values (?, ?)"
+	stmt, _ := conn.Prepare(sql)
+	defer stmt.Close()
+	_, _ = stmt.Exec(42, "turso")
+	rows, _ := conn.Query("SELECT * from go_turso")
+	defer rows.Close()
+	for rows.Next() {
+		var a int
+		var b string
 		_ = rows.Scan(&a, &b)
-        fmt.Printf("%d, %s", a, b)
-    }
+		fmt.Printf("%d, %s", a, b)
+	}
 }
+
 ```
 
 ## Implementation Notes


### PR DESCRIPTION
The example provided in the readme doesn't compile due to missing the package declaration, a missing os import, and gives the error ``assignment mismatch: 1 variable but conn.Exec returns 2 values`` because sql.Exec returns ``(sql.Result, error)`` and you're only discarding one of the return values. 